### PR TITLE
[OT210-73] proteger las rutas que solo sean accesibles para administradores

### DIFF
--- a/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.alkemy.ong.configuration;
 
+import com.alkemy.ong.common.exception.handler.AuthenticationEntryPointHandler;
+import com.alkemy.ong.common.exception.handler.CustomAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -14,7 +18,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable().authorizeRequests().anyRequest().permitAll();
+        http.csrf().disable().authorizeRequests().antMatchers(HttpMethod.POST).hasRole("ADMIN")
+                .antMatchers(HttpMethod.PATCH).hasRole("ADMIN")
+                .antMatchers(HttpMethod.DELETE).hasRole("ADMIN")
+                .antMatchers(HttpMethod.PUT).hasRole("ADMIN")
+                .antMatchers(HttpMethod.GET).authenticated()
+                .and().exceptionHandling()
+                .authenticationEntryPoint(new AuthenticationEntryPointHandler())
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .and().sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);;
     }
 
 }

--- a/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
@@ -18,7 +18,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable().authorizeRequests().antMatchers(HttpMethod.POST).hasRole("ADMIN")
+        http.csrf().disable().authorizeRequests()
+                .antMatchers("/api/docs/**", "/api/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .antMatchers(HttpMethod.POST).hasRole("ADMIN")
                 .antMatchers(HttpMethod.PATCH).hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE).hasRole("ADMIN")
                 .antMatchers(HttpMethod.PUT).hasRole("ADMIN")


### PR DESCRIPTION
## Why is this change required?

COMO: desarrollador.
QUIERO validar el rol del usuario administrador.
PARA proteger las rutas que solo sean accesibles para administradores.
Deberán protegerse las rutas con JWT para evitar las operaciones de creación, actualización y eliminación de las entidades del sistema, sean accesibles por Usuarios regulares.

### Motivation and Summary
<!--
- JIRA Ticket, Rally Story, etc
-->

### Type of change
- [ ] New feature
- [ ] New Tests
- [ ] Bug fix
- [ ] Refactor

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
