### PR TITLE
 [OT210-82] Add Pagination to Members created

### DIFF
--- a/src/main/java/com/alkemy/ong/domain/model/MemberList.java
+++ b/src/main/java/com/alkemy/ong/domain/model/MemberList.java
@@ -1,0 +1,12 @@
+package com.alkemy.ong.domain.model;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class MemberList extends PageImpl<Member> {
+    public MemberList(List<Member> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+}

--- a/src/main/java/com/alkemy/ong/domain/usecase/MemberService.java
+++ b/src/main/java/com/alkemy/ong/domain/usecase/MemberService.java
@@ -1,8 +1,12 @@
 package com.alkemy.ong.domain.usecase;
 
 import com.alkemy.ong.domain.model.Member;
+import com.alkemy.ong.domain.model.MemberList;
+import org.springframework.data.domain.PageRequest;
 
 public interface MemberService {
 
     Long createEntity(Member entity);
+
+    MemberList getList(PageRequest pageRequest);
 }

--- a/src/main/java/com/alkemy/ong/domain/usecase/impl/MemberServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/domain/usecase/impl/MemberServiceImpl.java
@@ -1,9 +1,12 @@
 package com.alkemy.ong.domain.usecase.impl;
 
 import com.alkemy.ong.domain.model.Member;
+import com.alkemy.ong.domain.model.MemberList;
 import com.alkemy.ong.domain.repository.MemberRepository;
 import com.alkemy.ong.domain.usecase.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,5 +20,12 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public Long createEntity(Member member) {
         return memberJpaRepository.save(member).getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberList getList(PageRequest pageRequest) {
+        Page<Member> page = memberJpaRepository.findAll(pageRequest);
+        return new MemberList(page.getContent(), pageRequest, page.getTotalElements());
     }
 }

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/MemberApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/MemberApi.java
@@ -1,13 +1,16 @@
 package com.alkemy.ong.ports.input.rs.api;
 
 import com.alkemy.ong.ports.input.rs.request.CreateMemberRequest;
+import com.alkemy.ong.ports.input.rs.response.MemberResponseList;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
+import java.util.Optional;
 
 @Validated
 public interface MemberApi {
     ResponseEntity<Void> createMember(@Valid CreateMemberRequest createMemberRequest);
 
+    ResponseEntity<MemberResponseList> getMembers(Optional<Integer> page, Optional<Integer> size);
 }

--- a/src/main/java/com/alkemy/ong/ports/input/rs/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/controller/MemberController.java
@@ -1,12 +1,18 @@
 package com.alkemy.ong.ports.input.rs.controller;
 
 import com.alkemy.ong.domain.model.Member;
+import com.alkemy.ong.domain.model.MemberList;
 import com.alkemy.ong.domain.usecase.MemberService;
+import com.alkemy.ong.ports.input.rs.api.ApiConstants;
 import com.alkemy.ong.ports.input.rs.api.MemberApi;
 import com.alkemy.ong.ports.input.rs.mapper.MemberControllerMapper;
 import com.alkemy.ong.ports.input.rs.request.CreateMemberRequest;
+import com.alkemy.ong.ports.input.rs.response.MemberResponse;
+import com.alkemy.ong.ports.input.rs.response.MemberResponseList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +21,8 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.util.List;
+import java.util.Optional;
 
 import static com.alkemy.ong.ports.input.rs.api.ApiConstants.MEMBERS_URI;
 
@@ -42,4 +50,31 @@ public class MemberController implements MemberApi {
         return ResponseEntity.created(location).build();
     }
 
+    @Override
+    @GetMapping
+    public ResponseEntity<MemberResponseList> getMembers(Optional<Integer> page, Optional<Integer> size) {
+
+        final int pageNumber = page.filter(p -> p > 0).orElse(ApiConstants.DEFAULT_PAGE);
+        final int pageSize = size.filter(s -> s > 0).orElse(ApiConstants.DEFAULT_PAGE_SIZE);
+
+        MemberList memberList = service.getList(PageRequest.of(pageNumber, pageSize));
+
+        MemberResponseList responseList;
+        {
+            responseList = new MemberResponseList();
+
+            List<MemberResponse> memberResponseList = mapper.memberListToMemberResponseList(memberList.getContent());
+            responseList.setContent(memberResponseList);
+
+            final int nextPage = memberList.getPageable().next().getPageNumber();
+            responseList.setNextUri(ApiConstants.uriByPageAsString.apply(nextPage));
+
+            final int previousPage = memberList.getPageable().previousOrFirst().getPageNumber();
+            responseList.setPreviousUri(ApiConstants.uriByPageAsString.apply(previousPage));
+
+            responseList.setTotalPages(memberList.getTotalPages());
+            responseList.setTotalElements(memberList.getTotalElements());
+        }
+        return ResponseEntity.ok().body(responseList);
+    }
 }

--- a/src/main/java/com/alkemy/ong/ports/input/rs/mapper/MemberControllerMapper.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/mapper/MemberControllerMapper.java
@@ -2,10 +2,17 @@ package com.alkemy.ong.ports.input.rs.mapper;
 
 import com.alkemy.ong.domain.model.Member;
 import com.alkemy.ong.ports.input.rs.request.CreateMemberRequest;
+import com.alkemy.ong.ports.input.rs.response.MemberResponse;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper
-public interface MemberControllerMapper extends CommonMapper{
+public interface MemberControllerMapper extends CommonMapper {
 
     Member createMemberRequestToMember(CreateMemberRequest create);
+
+    List<MemberResponse> memberListToMemberResponseList(List<Member> members);
+
+    MemberResponse memberToMemberResponse(Member member);
 }

--- a/src/main/java/com/alkemy/ong/ports/input/rs/response/MemberResponse.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/response/MemberResponse.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.ports.input.rs.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberResponse {
+
+    private Long id;
+    private String name;
+    private String image;
+    private String description;
+    private String facebookUrl;
+    private String instagramUrl;
+    private String linkedinUrl;
+}

--- a/src/main/java/com/alkemy/ong/ports/input/rs/response/MemberResponseList.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/response/MemberResponseList.java
@@ -1,0 +1,18 @@
+package com.alkemy.ong.ports.input.rs.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberResponseList {
+    private List<MemberResponse> content = null;
+    private String nextUri;
+    private String previousUri;
+    private Integer totalPages;
+    private Long totalElements;
+}


### PR DESCRIPTION
## Why is this change required?

### Motivation and Summary

Descripción

COMO usuario
QUIERO visualizar los resultados de Miembros paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page

### Type of change
- [x] New feature
- [ ] New Tests
- [ ] Bug fix
- [ ] Refactor

### Checklist

- [x] Traceability between this change and Jira.
- [x] ```mvn clean install``` was run and all tests completed successfully.
- [x] There are no unused variables and/or imports in the modified classes.
- [x] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.

==============================================================================

Miembros para listar cargados en la base de datos

![Snag_2d9a86b](https://user-images.githubusercontent.com/92120975/172967529-13905f52-fb31-4117-bd92-4a37eb561358.png)

Ahora mediante Postman listo todos los miembros de la base de datos de forma paginada.
En Postman configuro que empiece desde la primera página y con un tamaño de 2 miembros por página.

![Snag_2dd102f](https://user-images.githubusercontent.com/92120975/172967875-0854fbeb-6d5a-45cd-bbc4-b2806c650520.png)

Y en ésta imágen vemos la segunda página con la lista de miembros

![Snag_2de37a7](https://user-images.githubusercontent.com/92120975/172967981-37130946-70b3-47d4-aff4-a89d87eeb6d2.png)

