### PR TITLE
[OT210-84] Agregar documentacion con Swagger

### DIFF
--- a/src/main/java/com/alkemy/ong/configuration/OpenApiConfig.java
+++ b/src/main/java/com/alkemy/ong/configuration/OpenApiConfig.java
@@ -1,4 +1,18 @@
 package com.alkemy.ong.configuration;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "ONG Project", version = "v1"))
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
 public class OpenApiConfig {
 }

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/ActivityApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/ActivityApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -15,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface ActivityApi {
     ResponseEntity<Void> createActivity(@Valid CreateActivityRequest createActivityRequest);

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/AlkymerApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/AlkymerApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -19,6 +20,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface AlkymerApi {
 

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/CategoryApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/CategoryApi.java
@@ -1,11 +1,13 @@
 package com.alkemy.ong.ports.input.rs.api;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import com.alkemy.ong.ports.input.rs.request.CreateCategoryRequest;
 import org.springframework.validation.annotation.Validated;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface CategoryApi {
 

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/ContactApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/ContactApi.java
@@ -1,13 +1,11 @@
 package com.alkemy.ong.ports.input.rs.api;
 
 import com.alkemy.ong.ports.input.rs.request.CreateContactRequest;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 
-@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface ContactApi {
 

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/ContactApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/ContactApi.java
@@ -1,11 +1,13 @@
 package com.alkemy.ong.ports.input.rs.api;
 
 import com.alkemy.ong.ports.input.rs.request.CreateContactRequest;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface ContactApi {
 

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/MemberApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/MemberApi.java
@@ -1,11 +1,13 @@
 package com.alkemy.ong.ports.input.rs.api;
 
 import com.alkemy.ong.ports.input.rs.request.CreateMemberRequest;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface MemberApi {
     ResponseEntity<Void> createMember(@Valid CreateMemberRequest createMemberRequest);

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/OrganizationApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/OrganizationApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -17,6 +18,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface OrganizationApi {
 

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/TestimonialApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/TestimonialApi.java
@@ -3,11 +3,13 @@ package com.alkemy.ong.ports.input.rs.api;
 import com.alkemy.ong.ports.input.rs.request.CreateTestimonialRequest;
 import com.alkemy.ong.ports.input.rs.request.TestimonialRequest;
 import com.alkemy.ong.ports.input.rs.response.TestimonialResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface TestimonialApi {
 

--- a/src/main/java/com/alkemy/ong/ports/input/rs/api/UserApi.java
+++ b/src/main/java/com/alkemy/ong/ports/input/rs/api/UserApi.java
@@ -1,12 +1,14 @@
 package com.alkemy.ong.ports.input.rs.api;
 
 import com.alkemy.ong.ports.input.rs.response.UserResponseList;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
+@SecurityRequirement(name = "bearerAuth")
 @Validated
 public interface UserApi {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,9 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+# Swagger
+springdoc.swagger-ui.path=/api/docs
+
 # jackson json format
 spring.jackson.default-property-inclusion=non_null
 spring.jackson.property-naming-strategy=com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy
@@ -35,3 +38,4 @@ jwt.expiration=43200000
 # Register config
 default.organization.id=1
 default.role.id=1
+


### PR DESCRIPTION
## Why is this change required?

COMO desarrollador
QUIERO disponer de una documentación de los endpoints de la API
PARA tener referencias del funcionamiento del sistema

Criterios de aceptación:
Se deberá implementar la librería Swagger para documentar los diferentes endpoints del proyecto. Al ingresar al endpoint /api/docs, se deberá mostrar el layout. Adicionalmente, agregar la posibilidad para implementar los diferentes schemas en base a los Comentarios de métodos de cada controlador.

### Type of change
- [x] New feature
- [ ] New Tests
- [ ] Bug fix
- [ ] Refactor

### Checklist

- [x] Traceability between this change and Jira.
- [x] ```mvn clean install``` was run and all tests completed successfully.
- [x] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
