### PR TITLE
[OT210-93] Test: Endpoints /news

### DIFF
--- a/src/test/java/com/alkemy/ong/ports/input/rs/controller/NewControllerIT.java
+++ b/src/test/java/com/alkemy/ong/ports/input/rs/controller/NewControllerIT.java
@@ -1,0 +1,136 @@
+package com.alkemy.ong.ports.input.rs.controller;
+
+import com.alkemy.ong.H2Config;
+import com.alkemy.ong.common.util.JsonUtils;
+import com.alkemy.ong.domain.model.New;
+import com.alkemy.ong.ports.input.rs.api.ApiConstants;
+import com.alkemy.ong.ports.input.rs.request.CreateNewRequest;
+import com.alkemy.ong.ports.input.rs.request.TestimonialRequest;
+import com.alkemy.ong.ports.input.rs.response.AlkymerResponseList;
+import com.alkemy.ong.ports.input.rs.response.NewResponse;
+import com.alkemy.ong.ports.input.rs.response.NewResponseList;
+import com.alkemy.ong.ports.input.rs.response.TestimonialResponse;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@SpringJUnitConfig(classes = H2Config.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class NewControllerIT {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @Order(1)
+    @WithUserDetails("admin@somosmas.org")
+    void createNew_shouldReturn201() throws Exception {
+
+        CreateNewRequest request = CreateNewRequest.builder()
+                .name("noticia")
+                .content("contenido")
+                .image("image.png")
+                .build();
+        final String actualLocation = mockMvc.perform(post(ApiConstants.NEWS_URI)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtils.objectToJson(request)))
+                .andExpect(status().isCreated())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getHeader(HttpHeaders.LOCATION);
+
+        assertThat(actualLocation).isEqualTo("http://localhost/v1/new/99");
+    }
+
+    @Test
+    @Order(2)
+    @WithUserDetails("admin@somosmas.org")
+    void getNews_shouldReturn200() throws Exception {
+
+        String content = mockMvc.perform(get(ApiConstants.NEWS_URI))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(content).isNotBlank();
+
+        NewResponseList response = JsonUtils.jsonToObject(content, NewResponseList.class);
+
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(response.getTotalPages()).isEqualTo(1);
+        assertThat(response.getNextUri()).isEqualTo("http://localhost/v1/news?page=1");
+        assertThat(response.getPreviousUri()).isEqualTo("http://localhost/v1/news?page=0");
+        assertThat(response.getContent()).isNotEmpty();
+
+    }
+
+    @Test
+    @Order(3)
+    @WithUserDetails("admin@somosmas.org")
+    void updateNew_shouldReturn200() throws Exception {
+        CreateNewRequest update = CreateNewRequest.builder()
+                .name("Name UPDATED")
+                .content("Content UPDATED")
+                .image("Image UPDATED")
+                .build();
+
+        String content = mockMvc.perform(put(ApiConstants.NEWS_URI + "/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtils.objectToJson(update)))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(content).isNotBlank();
+
+        NewResponse response = JsonUtils.jsonToObject(content, NewResponse.class);
+
+        assertThat(response.getName()).isEqualTo("Name UPDATED");
+        assertThat(response.getContent()).isEqualTo("Content UPDATED");
+        assertThat(response.getImage()).isEqualTo("Image UPDATED");
+    }
+
+    @Test
+    @Order(4)
+    @WithUserDetails("admin@somosmas.org")
+    void deleteNew_shouldReturn204() throws Exception {
+        mockMvc.perform(delete(ApiConstants.NEWS_URI + "/1"))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+    @Test
+    @Order(5)
+    @WithUserDetails("jdoe@somosmas.org")
+    void deleteNew_shouldReturn403() throws Exception {
+        mockMvc.perform(delete(ApiConstants.NEWS_URI + "/1"))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+
+}

--- a/src/test/java/com/alkemy/ong/ports/input/rs/controller/NewControllerTest.java
+++ b/src/test/java/com/alkemy/ong/ports/input/rs/controller/NewControllerTest.java
@@ -1,0 +1,138 @@
+package com.alkemy.ong.ports.input.rs.controller;
+
+import com.alkemy.ong.common.exception.handler.GlobalExceptionHandler;
+import com.alkemy.ong.common.util.JsonUtils;
+import com.alkemy.ong.domain.model.Alkymer;
+import com.alkemy.ong.domain.model.New;
+import com.alkemy.ong.domain.model.NewList;
+import com.alkemy.ong.domain.usecase.NewService;
+import com.alkemy.ong.ports.input.rs.api.ApiConstants;
+import com.alkemy.ong.ports.input.rs.mapper.NewControllerMapper;
+import com.alkemy.ong.ports.input.rs.request.CreateNewRequest;
+import com.alkemy.ong.ports.input.rs.request.TestimonialRequest;
+import com.alkemy.ong.ports.input.rs.response.ContactResponseList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class NewControllerTest {
+
+    private MockMvc mockMvc;
+
+    @InjectMocks
+    NewController controller;
+
+    @Mock
+    NewService service;
+
+    @Spy
+    NewControllerMapper mapper = Mappers.getMapper(NewControllerMapper.class);
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler.class)
+                .build();
+    }
+
+    @Test
+    void createNew_shouldReturn201() throws Exception{
+        CreateNewRequest request = CreateNewRequest.builder()
+                .name("noticia")
+                .content("contenido")
+                .image("image.png")
+                .build();
+        given(service.createNew(any(New.class))).willReturn(99L);
+
+        final String actualLocation = mockMvc.perform(post(ApiConstants.NEWS_URI)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtils.objectToJson(request)))
+                .andExpect(status().isCreated())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getHeader(HttpHeaders.LOCATION);
+
+        assertThat(actualLocation).isEqualTo("http://localhost/v1/new/99");
+    }
+
+    @Test
+    void getNews_shouldReturn200() throws Exception {
+
+        New news = new New();
+        news.setContent("content");
+        news.setImage("image.png");
+        news.setName("new");
+        news.setId(99L);
+        NewList list = new NewList(List.of(news), Pageable.ofSize(1), 1);
+
+        given(service.getList(any(PageRequest.class))).willReturn(list);
+        String content = mockMvc.perform(get(ApiConstants.NEWS_URI + "?page=0&size=1"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(content).isNotBlank();
+
+        ContactResponseList response = JsonUtils.jsonToObject(content, ContactResponseList.class);
+
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(response.getTotalPages()).isEqualTo(1);
+        assertThat(response.getNextUri()).isEqualTo("http://localhost/v1/news?size=1&page=1");
+        assertThat(response.getPreviousUri()).isEqualTo("http://localhost/v1/news?size=1&page=0");
+        assertThat(response.getContent()).isNotEmpty();
+    }
+
+    @Test
+    void updateNew_shouldReturn200() throws Exception {
+        CreateNewRequest update = CreateNewRequest.builder()
+                .name("Name UPDATED")
+                .content("Content UPDATED")
+                .image("Image UPDATED")
+                .build();
+
+        mockMvc.perform(put(ApiConstants.NEWS_URI + "/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtils.objectToJson(update)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    void deleteNew_shouldReturn204() throws Exception {
+
+        mockMvc.perform(delete(ApiConstants.NEWS_URI + "/1"))
+                .andExpect(status().isNoContent())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+    }
+
+
+
+}


### PR DESCRIPTION
## Why is this change required?

COMO desarrollador
QUIERO disponer de tests de los endpoints de /news
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.

### Motivation and Summary
<!--
- JIRA Ticket, Rally Story, etc
-->

### Type of change
- [ ] New feature
- [ ] New Tests
- [ ] Bug fix
- [ ] Refactor

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
